### PR TITLE
Fix crash when a key is pressed before ScriptDomain is loaded

### DIFF
--- a/SHVDNPro/core/Input.cpp
+++ b/SHVDNPro/core/Input.cpp
@@ -11,7 +11,7 @@ void ManagedScriptKeyboardMessage(unsigned long key, unsigned short repeats, uns
 		return;
 	}
 
-	if (!GTA::ManagedGlobals::g_scriptDomain->isDomainInitialized()) {
+	if (GTA::ManagedGlobals::g_scriptDomain == nullptr || !GTA::ManagedGlobals::g_scriptDomain->isDomainInitialized()) {
 		return;
 	}
 

--- a/SHVDNPro/core/Input.cpp
+++ b/SHVDNPro/core/Input.cpp
@@ -11,6 +11,10 @@ void ManagedScriptKeyboardMessage(unsigned long key, unsigned short repeats, uns
 		return;
 	}
 
+	if (!GTA::ManagedGlobals::g_scriptDomain->isDomainInitialized()) {
+		return;
+	}
+
 	bool ctrl = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
 	bool shift = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
 	bool status = !isUpNow;

--- a/SHVDNPro/core/Main.cpp
+++ b/SHVDNPro/core/Main.cpp
@@ -67,6 +67,7 @@ void LoadScriptDomain()
 	GTA::WriteLog("Created ScriptDomain!");
 
 	GTA::ManagedGlobals::g_scriptDomain->FindAllTypes();
+	GTA::ManagedGlobals::g_scriptDomain->setDomainInitialized(true);
 }
 
 static bool ManagedScriptInit(int scriptIndex, void* fiberMain, void* fiberScript)

--- a/SHVDNPro/core/ScriptDomain.cpp
+++ b/SHVDNPro/core/ScriptDomain.cpp
@@ -15,6 +15,8 @@ GTA::ScriptDomain::ScriptDomain()
 	System::AppDomain::CurrentDomain->AssemblyResolve += gcnew System::ResolveEventHandler(this, &GTA::ScriptDomain::OnAssemblyResolve);
 
 	GTA::ManagedGlobals::g_scriptDomain = this;
+
+	domainInitialized = false;
 }
 
 void GTA::ScriptDomain::FindAllTypes()
@@ -186,4 +188,14 @@ System::Reflection::Assembly^ GTA::ScriptDomain::OnAssemblyResolve(System::Objec
 	}
 
 	return nullptr;
+}
+
+bool GTA::ScriptDomain::isDomainInitialized()
+{
+	return domainInitialized;
+}
+
+void GTA::ScriptDomain::setDomainInitialized(bool value)
+{
+	domainInitialized = value;
 }

--- a/SHVDNPro/core/ScriptDomain.h
+++ b/SHVDNPro/core/ScriptDomain.h
@@ -9,6 +9,7 @@ namespace GTA
 	internal:
 		array<System::Type^>^ m_types;
 		array<GTA::Script^>^ m_scripts;
+		bool domainInitialized;
 
 	public:
 		ScriptDomain();
@@ -28,5 +29,8 @@ namespace GTA
 
 		void OnUnhandledException(System::Object^ sender, System::UnhandledExceptionEventArgs^ e);
 		System::Reflection::Assembly^ OnAssemblyResolve(System::Object^ sender, System::ResolveEventArgs^ args);
+
+		bool isDomainInitialized();
+		void setDomainInitialized(bool value);
 	};
 }


### PR DESCRIPTION
#2 made keyboard input work, but a bug was introduced, you can send a keyboard message to the script domain before it's initialized

This PR adds the ability to check if ScriptDomain is initialized and fixes that crash.